### PR TITLE
Renamed DEFAULT and SAT to OVERFLOW_DEFAULT and OVERFLOW_SAT

### DIFF
--- a/src/avrfix.h
+++ b/src/avrfix.h
@@ -42,11 +42,11 @@ typedef signed long  lfix_t;
 
 /* Pragmas for defining overflow behaviour */
 
-#define DEFAULT    0
-#define SAT        1
+#define OVERFLOW_DEFAULT    0
+#define OVERFLOW_SAT        1
 
 #ifndef FX_ACCUM_OVERFLOW
-#define FX_ACCUM_OVERFLOW DEFAULT
+#define FX_ACCUM_OVERFLOW OVERFLOW_DEFAULT
 #endif
 
 /* Pragmas for internal use */
@@ -131,14 +131,14 @@ sfix_t sdivskS(sfix_t, sfix_t);
 fix_t divkS(fix_t, fix_t);
 lfix_t ldivlkS(lfix_t, lfix_t);
 
-#if FX_ACCUM_OVERFLOW == DEFAULT
+#if FX_ACCUM_OVERFLOW == OVERFLOW_DEFAULT
   #define smulsk(a,b) smulskD((a),(b))
   #define mulk(a,b) mulkD((a),(b))
   #define lmullk(a,b) lmullkD((a), (b))
   #define sdivsk(a,b) sdivskD((a), (b))
   #define divk(a,b) divkD((a), (b))
   #define ldivlk(a,b) ldivlkD((a), (b))
-#elif FX_ACCUM_OVERFLOW == SAT
+#elif FX_ACCUM_OVERFLOW == OVERFLOW_SAT
   #define smulsk(a,b) smulskS((a),(b))
   #define mulk(a,b) mulkS((a),(b))
   #define lmullk(a,b) lmullkS((a), (b))
@@ -173,7 +173,7 @@ lfix_t ldivlkS(lfix_t, lfix_t);
 #define idivkS(a,b) ktoi(divkS((a),(b)))
 #define idivlkS(a,b) lktoi(ldivlkS((a),(b)))
 
-#if FX_ACCUM_OVERFLOW == DEFAULT
+#if FX_ACCUM_OVERFLOW == OVERFLOW_DEFAULT
   #define mulik(a,b) mulikD((a),(b))
   #define mulilk(a,b) mulilkD((a),(b))
   #define divik(a,b) divikD((a),(b))
@@ -182,7 +182,7 @@ lfix_t ldivlkS(lfix_t, lfix_t);
   #define lkdivi(a,b) lkdiviD((a),(b))
   #define idivk(a,b) idivkD((a),(b))
   #define idivlk(a,b) idivlkD((a),(b))
-#elif FX_ACCUM_OVERFLOW == SAT
+#elif FX_ACCUM_OVERFLOW == OVERFLOW_SAT
   #define mulik(a,b) mulikS((a),(b))
   #define mulilk(a,b) mulilkS((a),(b))
   #define divik(a,b) divikS((a),(b))
@@ -209,11 +209,11 @@ sfix_t roundskS(sfix_t f, uint8_t n);
 fix_t roundkS(fix_t f, uint8_t n);
 lfix_t roundlkS(lfix_t f, uint8_t n);
 
-#if FX_ACCUM_OVERFLOW == DEFAULT
+#if FX_ACCUM_OVERFLOW == OVERFLOW_DEFAULT
   #define roundsk(f, n) roundskD((f), (n))
   #define roundk(f, n) roundkD((f), (n))
   #define roundlk(f, n) roundlkD((f), (n))
-#elif FX_ACCUM_OVERFLOW == SAT
+#elif FX_ACCUM_OVERFLOW == OVERFLOW_SAT
   #define roundsk(f, n) roundskS((f), (n))
   #define roundk(f, n) roundkS((f), (n))
   #define roundlk(f, n) roundlkS((f), (n))
@@ -269,11 +269,11 @@ fix_t tankS(fix_t);
 lfix_t ltanlkS(lfix_t);
 lfix_t ltankS(fix_t);
 
-#if FX_ACCUM_OVERFLOW == DEFAULT
+#if FX_ACCUM_OVERFLOW == OVERFLOW_DEFAULT
   #define tank(a) tankD((a))
   #define ltanlk(a) ltanlkD((a))
   #define ltank(a) ltankD((a))
-#elif FX_ACCUM_OVERFLOW == SAT
+#elif FX_ACCUM_OVERFLOW == OVERFLOW_SAT
   #define tank(a) tankS((a))
   #define ltanlk(a) ltanlkS((a))
   #define ltank(a) ltankS((a))


### PR DESCRIPTION
... to avoid clash with Arduino.h definition

Arduino.h defines a DEFAULT macro that clashes with avrfix. I prefixed them with OVERFLOW_.